### PR TITLE
Updates for STAR Forward Tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ INCLUDE_DIRECTORIES( BEFORE
 INSTALL( DIRECTORY ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 # add library
+AUX_SOURCE_DIRECTORY( ./src/marlin library_sources )
 AUX_SOURCE_DIRECTORY( ./src/Criteria library_sources )
 AUX_SOURCE_DIRECTORY( ./src/KiTrack library_sources )  
 

--- a/include/KiTrack/Automaton.h
+++ b/include/KiTrack/Automaton.h
@@ -132,7 +132,7 @@ namespace KiTrack{
        * to layer 0. All those get deleted by this method.
        * (Of course all the connections to them are erased as well)
        */
-      void cleanBadStates();
+      void cleanBadStates( int LayerOffset );
       
       /**
        * Erase alls connections between segments, that don't satisfy the criteria.

--- a/include/KiTrack/Automaton.h
+++ b/include/KiTrack/Automaton.h
@@ -132,7 +132,7 @@ namespace KiTrack{
        * to layer 0. All those get deleted by this method.
        * (Of course all the connections to them are erased as well)
        */
-      void cleanBadStates( int LayerOffset );
+      void cleanBadStates( int LayerOffset = 0 );
       
       /**
        * Erase alls connections between segments, that don't satisfy the criteria.

--- a/include/marlin/VerbosityLevels.h
+++ b/include/marlin/VerbosityLevels.h
@@ -1,8 +1,58 @@
 #ifndef marlin_VerbosityLevels_h
 #define marlin_VerbosityLevels_h
 
-#include <iostream>
+#include "marlin/streamlog.h"
 
-#define streamlog_out(LEVEL) std::cout << #LEVEL
+// import the log level classes into the marlin namespace 
+
+namespace marlin{
+
+  using  streamlog::DEBUG ;
+  using  streamlog::DEBUG0 ;
+  using  streamlog::DEBUG1 ;
+  using  streamlog::DEBUG2 ;
+  using  streamlog::DEBUG3 ;
+  using  streamlog::DEBUG4 ;
+  using  streamlog::DEBUG5 ;
+  using  streamlog::DEBUG6 ;
+  using  streamlog::DEBUG7 ;
+  using  streamlog::DEBUG8 ;
+  using  streamlog::DEBUG9 ;
+  using  streamlog::MESSAGE ;
+  using  streamlog::MESSAGE0 ;
+  using  streamlog::MESSAGE1 ;
+  using  streamlog::MESSAGE2 ;
+  using  streamlog::MESSAGE3 ;
+  using  streamlog::MESSAGE4 ;
+  using  streamlog::MESSAGE5 ;
+  using  streamlog::MESSAGE6 ;
+  using  streamlog::MESSAGE7 ;
+  using  streamlog::MESSAGE8 ;
+  using  streamlog::MESSAGE9 ;
+  using  streamlog::WARNING ;
+  using  streamlog::WARNING0 ;
+  using  streamlog::WARNING1 ;
+  using  streamlog::WARNING2 ;
+  using  streamlog::WARNING3 ;
+  using  streamlog::WARNING4 ;
+  using  streamlog::WARNING5 ;
+  using  streamlog::WARNING6 ;
+  using  streamlog::WARNING7 ;
+  using  streamlog::WARNING8 ;
+  using  streamlog::WARNING9 ;
+  using  streamlog::ERROR ;
+  using  streamlog::ERROR0 ;
+  using  streamlog::ERROR1 ;
+  using  streamlog::ERROR2 ;
+  using  streamlog::ERROR3 ;
+  using  streamlog::ERROR4 ;
+  using  streamlog::ERROR5 ;
+  using  streamlog::ERROR6 ;
+  using  streamlog::ERROR7 ;
+  using  streamlog::ERROR8 ;
+  using  streamlog::ERROR9 ;
+  using  streamlog::SILENT ;
+
+}
 
 #endif

--- a/include/marlin/baselevels.h
+++ b/include/marlin/baselevels.h
@@ -1,0 +1,74 @@
+// -*- mode: c++;
+
+#ifndef baselevels_h
+#define baselevels_h
+/* 
+ *  Define base log level classes for streamlog::logstream. There are the following
+ *  groups of log level classes: DEBUG, WARNING, MESSAGE and ERROR. 
+ *  By default all groups are active, except DEBUG when compiled with
+ *  -DNDEBUG, i.e. in release mode.
+ *  Through -DSTREAMLOG_LEVEL=N, where N=0,1,2,3,4 this behaviour can be changed, e.g.
+ *  if -DSTREAMLOG_LEVEL=2 is specified at compile time all messages of the groups
+ *  DEBUG and MESSAGE are suppressed (no overhead in space or time) and only WARNING
+ *  and ERROR messages will be visible if the current log level is reached.
+ *  
+ *  @author F. Gaede, DESY
+ *  @version $Id: baselevels.h,v 1.2 2007-07-13 11:09:04 gaede Exp $
+ */
+
+
+namespace streamlog{
+
+#define STREAMLOG_MAX_LEVEL 0xFFFFFFFF 
+    
+#ifndef STREAMLOG_LEVEL
+ #ifndef NDEBUG
+  #define STREAMLOG_LEVEL 0
+ #else
+  #define STREAMLOG_LEVEL 1
+ #endif
+#endif
+
+#if STREAMLOG_LEVEL > 3
+  #define STREAMLOG_ERROR_ACTIVE false
+#else
+  #define STREAMLOG_ERROR_ACTIVE true
+#endif
+
+#if STREAMLOG_LEVEL > 2
+  #define STREAMLOG_WARNING_ACTIVE false
+#else
+  #define STREAMLOG_WARNING_ACTIVE true
+#endif
+
+#if STREAMLOG_LEVEL > 1
+  #define STREAMLOG_MESSAGE_ACTIVE false
+#else
+  #define STREAMLOG_MESSAGE_ACTIVE true
+#endif
+
+#if STREAMLOG_LEVEL > 0
+  #define STREAMLOG_DEBUG_ACTIVE false
+#else
+  #define STREAMLOG_DEBUG_ACTIVE true
+#endif
+
+  
+  template <unsigned LEVEL, bool ON>
+  struct Verbosity{
+    static const unsigned level = LEVEL ; 
+    static const bool active = ON ;
+  } ;
+
+
+
+  /** macro for registering a new loglevel class */
+#define DEFINE_STREAMLOG_LEVEL( ClassName, String, LOG_Level, Active )\
+  template <bool ON>\
+  struct  active_##ClassName : public Verbosity< (LOG_Level) , ON >{\
+    static const char* name() { return (String) ; }\
+  };\
+  typedef  active_##ClassName< Active > ClassName ; \
+
+}
+#endif

--- a/include/marlin/logbuffer.h
+++ b/include/marlin/logbuffer.h
@@ -1,0 +1,73 @@
+// -*- mode: c++;
+#ifndef logbuffer_h
+#define logbuffer_h
+
+#include <sstream>
+#include <cstdio>
+#include "marlin/logstream.h"
+
+namespace streamlog{
+
+
+  /** Helper class that adds a prefix to every new line that is written to its
+   *  std::ostream.
+   * 
+   *  @author F. Gaede, DESY
+   *  @version $Id: logbuffer.h,v 1.1.1.1 2007-07-12 17:14:48 gaede Exp $
+   */
+  class logbuffer : public std::streambuf {
+    
+    std::streambuf* _sbuf = nullptr ;
+    logstream* _ls = nullptr ;
+
+    logbuffer();
+
+
+  public:
+    logbuffer(const logbuffer&) = delete ;
+    logbuffer& operator=(const logbuffer&) = delete ;
+    logbuffer( std::streambuf* sbuf, logstream* logstream ) : _sbuf( sbuf ), _ls(logstream) {} 
+  
+    ~logbuffer() {
+    
+    }
+
+    
+  /** This is where the logstream's current prefix is  added to every
+   *  new line written to the std::ostream that has this logbuffer.
+   *  Idea taken from J.Samson, DESY.
+   */
+    inline virtual int overflow( int c = EOF ) {
+      
+      static bool hasNewLine = true ;
+      
+      if ( c == EOF ) 
+	return EOF ;
+    
+      bool success = true;
+    
+      if ( hasNewLine == true ) {
+	
+	std::string pre = (* _ls->prefix() )() ;
+
+	success &= (  (unsigned) _sbuf->sputn( pre.c_str() , pre.size() ) == pre.size()  ) ;
+
+	hasNewLine = false;
+      }
+
+      if ( c == '\n' )
+	hasNewLine = true;
+    
+      if ( success )
+	success &= ( _sbuf->sputc(c) != EOF ) ;
+    
+      if( success ) 
+	return 0 ;
+
+      return EOF ;
+    }
+
+  } ;
+
+}
+#endif

--- a/include/marlin/loglevels.h
+++ b/include/marlin/loglevels.h
@@ -1,0 +1,102 @@
+// -*- mode: c++;
+
+/** loglevels.h:
+ *  defines default log levels for streamlog
+ *  
+ *  Default log levels for streamlog::logstream:<br>
+ *  <b><ul> 
+ *   <li>DEBUG/DEBUG0, DEBUG1, DEBUG2, DEBUG3, DEBUG4 </li>
+ *   <li>MESSAGE/MESSAGE0,...  MESSAGE4</li>
+ *   <li> WARNING/WARNING0,... WARNING4</li>
+ *   <li>  ERROR/ERROR0,... ERROR4</li>
+ *  </ul></b>
+ *  By default all groups are active, except DEBUG when compiled with
+ *  -DNDEBUG, i.e. in release mode.
+ *  Through -DSTREAMLOG_LEVEL=N, where N=0,1,2,3,4 this behaviour can be changed, e.g.
+ *  if -DSTREAMLOG_LEVEL=2 is specified all compile time all messages of the groups
+ *  DEBUG and MESSAGE are suppressed (no overhead in space or time) and only WARNING
+ *  and ERROR messages will be visible if the current log level is reached.
+ * 
+ *  Users can define their own log levels or additional loglevels with the macro:
+ *  <pre>  DEFINE_STREAMLOG_LEVEL( classname,  "LogString",  loglevel , active_flag )  </pre>
+ *  if active flag is false corresponding code will have no effect.
+ * 
+ *  
+ *  @author F. Gaede, DESY
+ *  @version $Id: loglevels.h,v 1.3 2007-08-08 13:58:33 gaede Exp $
+ */
+
+#ifndef loglevels_h
+#define loglevels_h
+
+#include "marlin/baselevels.h"
+
+namespace streamlog{
+
+
+  enum log_level_enum{
+    debug_base_level=0,
+    message_base_level=100,
+    warning_base_level=200,
+    error_base_level=300
+  } ;
+
+  //  DEFINE_STREAMLOG_LEVEL( classname,  "LogString",  loglevel , active_flag ) 
+
+  DEFINE_STREAMLOG_LEVEL( DEBUG,   "DEBUG" ,  debug_base_level + 0 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG0,  "DEBUG0",  debug_base_level + 0 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG1,  "DEBUG1",  debug_base_level + 1 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG2,  "DEBUG2",  debug_base_level + 2 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG3,  "DEBUG3",  debug_base_level + 3 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG4,  "DEBUG4",  debug_base_level + 4 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG5,  "DEBUG5",  debug_base_level + 5 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG6,  "DEBUG6",  debug_base_level + 6 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG7,  "DEBUG7",  debug_base_level + 7 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG8,  "DEBUG8",  debug_base_level + 8 , STREAMLOG_DEBUG_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( DEBUG9,  "DEBUG9",  debug_base_level + 9 , STREAMLOG_DEBUG_ACTIVE ) 
+
+  DEFINE_STREAMLOG_LEVEL( MESSAGE,  "MESSAGE" , message_base_level + 0 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE0, "MESSAGE0", message_base_level + 0 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE1, "MESSAGE1", message_base_level + 1 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE2, "MESSAGE2", message_base_level + 2 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE3, "MESSAGE3", message_base_level + 3 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE4, "MESSAGE4", message_base_level + 4 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE5, "MESSAGE5", message_base_level + 5 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE6, "MESSAGE6", message_base_level + 6 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE7, "MESSAGE7", message_base_level + 7 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE8, "MESSAGE8", message_base_level + 8 , STREAMLOG_MESSAGE_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( MESSAGE9, "MESSAGE9", message_base_level + 9 , STREAMLOG_MESSAGE_ACTIVE ) 
+
+  DEFINE_STREAMLOG_LEVEL( WARNING,  "WARNING" , warning_base_level + 0 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING0, "WARNING0", warning_base_level + 0 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING1, "WARNING1", warning_base_level + 1 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING2, "WARNING2", warning_base_level + 2 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING3, "WARNING3", warning_base_level + 3 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING4, "WARNING4", warning_base_level + 4 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING5, "WARNING5", warning_base_level + 5 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING6, "WARNING6", warning_base_level + 6 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING7, "WARNING7", warning_base_level + 7 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING8, "WARNING8", warning_base_level + 8 , STREAMLOG_WARNING_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( WARNING9, "WARNING9", warning_base_level + 9 , STREAMLOG_WARNING_ACTIVE ) 
+
+  DEFINE_STREAMLOG_LEVEL( ERROR,  "ERROR" , error_base_level + 0 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR0, "ERROR0", error_base_level + 0 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR1, "ERROR1", error_base_level + 1 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR2, "ERROR2", error_base_level + 2 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR3, "ERROR3", error_base_level + 3 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR4, "ERROR4", error_base_level + 4 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR5, "ERROR5", error_base_level + 5 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR6, "ERROR6", error_base_level + 6 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR7, "ERROR7", error_base_level + 7 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR8, "ERROR8", error_base_level + 8 , STREAMLOG_ERROR_ACTIVE ) 
+  DEFINE_STREAMLOG_LEVEL( ERROR9, "ERROR9", error_base_level + 9 , STREAMLOG_ERROR_ACTIVE ) 
+
+
+    // use this to turn of all logging messages
+  DEFINE_STREAMLOG_LEVEL( SILENT, "SILENT" ,  STREAMLOG_MAX_LEVEL    , false ) 
+
+}
+
+#endif
+
+

--- a/include/marlin/logscope.h
+++ b/include/marlin/logscope.h
@@ -1,0 +1,77 @@
+#ifndef logscope_h
+#define logscope_h
+
+#include "marlin/logstream.h"
+
+namespace streamlog{
+
+  /** Helper class to change the current scope name and log level - 
+   *  if the object goes out of scope, e.g. at the end of the method
+   *  where it is instantiated scope name and log level will be reset to the values 
+   *  they had previously, i.e. before changed through this object.<br>
+   *  Example:
+   *  <pre>
+   *   streamlog::logscope scope( streamlog::out ) ;
+   *   scope.setName( "TrackFitter" ) ;
+   *   scope.setLevel< streamlog::MESSAGE3 >() ;
+   *  </pre>
+   *  
+   * 
+   *  @author F. Gaede, DESY
+   *  @version $Id: logscope.h,v 1.2 2007-07-13 11:09:04 gaede Exp $
+   */
+  class logscope{
+
+  public:
+    logscope() = delete ;
+    logscope(const logscope&) = delete ;
+    logscope& operator=(const logscope&) = delete ;
+
+    /** Instantiate a scope object for the given logstream.
+     */
+    logscope(logstream& ls) : _ls(&ls) , _name("") , _level(-1) { }
+    
+    /** Reset old name and level if set through this object.
+     */
+    ~logscope(){
+
+      if( _name.size() > 0 ) {
+	_ls->prefix()->_name=_name ;
+	//std::cerr << "  ~logscope()  reset name to " << _name << std::endl ;
+	
+      }
+      if(  _level > -1 )
+ 	_ls->setLevel( _level ) ; 
+    }
+    
+    /** Change current log scope name for the lifetime of this object */
+    void setName(const std::string name) {
+      _name =  _ls->prefix()->_name ;
+      _ls->prefix()->_name = name ;
+    }
+  
+
+    /** Change current log level for the lifetime of this object */
+    template <class T>
+    void setLevel(){
+      _level =  _ls->_level ;
+      _ls->setLevel( T::level )  ;
+    }
+
+    /** Change current log level for the lifetime of this object 
+     *  through a string level name that has been registered with the logstream
+     *  via logstream::addLevelName - otherwise the call will have no effect.
+     */
+    void setLevel(const std::string& level){
+      _level =  _ls->setLevel( level )  ;
+    }
+   
+  protected: 
+    logstream* _ls = nullptr ;
+    std::string _name{} ;
+    long _level{};
+    
+  };
+  
+}
+#endif

--- a/include/marlin/logstream.h
+++ b/include/marlin/logstream.h
@@ -1,0 +1,167 @@
+// -*- mode: c++;
+#ifndef logstream_h
+#define logstream_h
+
+#include "marlin/prefix.h"
+
+#include <iostream>
+#include <map>
+
+namespace streamlog{
+
+  class prefix_base ;
+  class logbuffer ;
+  class logscope ;
+
+
+  /** Class defining a log stream that is used to print log messages depending 
+   *  on current log level. Can be initialized with any std::ostream, typically either 
+   *  std::cout or an std::ofstream file handler.
+   *  There is one global instance of this class defined in the library: logstream::out  <br>
+   *  Typically only this instance is needed, e.g.: <br>
+   *  <pre>
+   *    // in int main() :
+   *    streamlog::out.init( std::cout, argv[0] ) ;
+   * 
+   *    //...
+   *    
+   *    if( streamlog::out.write< streamlog::DEBUG1 >() )
+   *       streamlog::out() << " this message will only be printed if level >= DEBUG1::level " 
+   *                        << std::endl ;
+   * 
+   *    // or the same, simply using a macro:
+   * 
+   *    streamlog_out( DEBUG )  << " this message will only be printed if level >= DEBUG1::level " 
+   *                            << std::endl ;
+   * 
+   *    
+   *  </pre>
+   *  Note that with the above calling sequence or the macro no runtime overhead is created
+   *  if streamlog::DEBUG1::active is false and else if the log level is smaller than 
+   *  streamlog::DEBUG1::level no formatting of the message will happen, i.e. also very little 
+   *  runtime cost is involved. <br>
+   *  the behaviour of the logstream, i.e. the current log level and log scope name can be changed only
+   *  through an object of streamlog::logscope.
+   * 
+   *  @see logstream::write() 
+   *  @see logscope
+   *
+   *  @author F. Gaede, DESY
+   *  @version $Id: logstream.h,v 1.3 2007-08-08 13:08:34 gaede Exp $
+   */
+  class logstream {
+
+    friend class logscope ;
+    friend class logbuffer ;
+
+
+    typedef std::map< std::string,  unsigned > LevelMap ;
+
+  public :
+
+    logstream() ; 
+    logstream(const logstream&) = delete ;
+    logstream& operator=(const logstream&) = delete ;
+    ~logstream() ;
+
+    /** Initialize the logstream with an std::ostream, e.g. std::cout and 
+     *  the main scope name, e.g. argv[0].
+     *  Only first call to this method has an effect, subsequent calls are ignored.
+     * 
+     */
+    void init( std::ostream& os , const std::string name ) ;
+
+   /** True if next log message of the current level (class T ) will be written, i.e.
+     *  the next call to std::ostream& operator()() will return a valid outstream.
+     * 
+     */
+    template<class T>
+    inline bool write() {
+      
+      // dont' call chek_level if T::active == false
+      return (  T::active   &&    check_level<T>()  ) ;
+    }
+
+    /** True if next log message of the current level (class T ) would be written
+     *  - can be used to conditionally execute code blocks that are needed before writing to
+     * the outstream.
+     * 
+     */
+    template<class T>
+    inline bool would_write() {
+      
+      return (  T::active   &&  T::level >= _level ) ;
+    }
+
+   /** Return the actual std::ostream where the message should be writen to - will return
+     *  a nullstream unless prepended by a successfull call to write<MESSAGELEVEL>()
+     */
+    std::ostream& operator()() ;
+
+    /** Adds a level name to the stream for setting the log level with a string through 
+     *  a scope class. Only names added with this method will have an effect - other log 
+     *  levels can only be activated with logstream::logscope::setLevel<T>().
+     *  Useful for framework programs where the log level can be changed via a steering 
+     *  parameter.
+     *  
+     *  @see logstream::logscope::setLevel(const std::string levelName )
+     */
+    template <class T>
+    void addLevelName() {
+
+      _map[ T::name() ] = T::level ;
+    }
+
+
+    // interface for friend classes: scope and logbuffer
+
+  protected:
+
+    /** Set the current level - user need to use a streamlog::logscope object 
+     *  to do this.
+     */
+    void setLevel( unsigned level ) { _level = level ; } 
+
+    /** Set the current level through its name - only level previously made known to
+     *  the stream through addLevelName will have an effect.
+     */
+    unsigned setLevel( const std::string& levelName )  ; 
+
+    /** Returns the prefix for the logbuffer object */
+    prefix_base* prefix() { return _prefix ; }
+
+    /** used internally by write<T> */
+    template<class T>
+    bool check_level() {
+      
+      if( T::level >= _level ){
+	_active = true ;
+	_prefix->_levelName = T::name() ;
+      }
+      return _active ;
+    }
+
+
+  private:
+
+    /** Private helper class returned if message log level not reached */ 
+    class nullstream :  public std::ostream {
+    public:
+      nullstream() : std::ios( 0 ), std::ostream( 0 ) {} ;
+    } ;
+  
+
+    nullstream* _ns = nullptr ;    // the nullstream
+    std::ostream* _os = nullptr ; // wrapper for actual ostream
+    unsigned _level {};   // current log level 
+    bool _active {};      // boolean helper 
+    logbuffer* _lb = nullptr ;        // log buffer adds prefix to everu log message
+    prefix_base* _prefix= nullptr ;  // prefix formatter
+    LevelMap _map {};         // string map of level names
+    
+  } ;
+
+  extern logstream out ;
+
+}
+#endif

--- a/include/marlin/prefix.h
+++ b/include/marlin/prefix.h
@@ -1,0 +1,57 @@
+// -*- mode: c++;
+#ifndef prefix_h
+#define prefix_h
+
+#include <sstream>
+
+namespace streamlog{
+
+  class logscope ;
+  class logstream ;
+
+
+  /** Base class for log message prefix formating. Subclasses need to define 
+   *  std::string operator()() using this->_levelName and this->_name.
+   * 
+   *  @author F. Gaede, DESY
+   *  @version $Id: prefix.h,v 1.1.1.1 2007-07-12 17:14:48 gaede Exp $
+   */
+  class prefix_base{
+  
+    friend class logscope ;
+    friend class logstream ;
+
+  protected:
+    std::string _name{} ;
+    std::string _levelName{} ;
+  
+  public:
+    prefix_base() ;
+    virtual ~prefix_base() ;
+ 
+    virtual std::string operator()() =0 ;
+    
+    void setLevelName( const std::string& lName) { _levelName = lName ; } 
+  
+  };
+
+  /** Default log message prefix:  [ LevelName "ScopeName"].
+   * 
+   *  @author F. Gaede, DESY
+   *  @version $Id: prefix.h,v 1.1.1.1 2007-07-12 17:14:48 gaede Exp $
+   */
+
+  class prefix : public prefix_base{
+  public:
+    virtual std::string operator()()  {
+      std::stringstream ss ;
+      ss << "[ " << this->_levelName << " \"" << this->_name << "\"] " ;
+      return ss.str() ;
+    }
+
+  };
+
+
+
+}
+#endif

--- a/include/marlin/streamlog.h
+++ b/include/marlin/streamlog.h
@@ -1,0 +1,57 @@
+// -*- mode: c++;
+#ifndef streamlog_h
+#define streamlog_h
+
+  /**
+   *  Main header file for the streamlog library. 
+   *  Includes necessary header files and defines macros <br>
+   *      streamlog_out( MLEVEL )  <br>
+   *      streamlog_message( MLEVEL , CODE_BLOCK , OUT_MESSAGE) <br>
+   * 
+   *  @author F. Gaede, DESY
+   *  @version $Id: streamlog.h,v 1.3 2007-09-12 11:59:53 gaede Exp $
+   */
+
+#ifndef DONT_USE_STREAMLOG
+#define USE_STREAMLOG 
+#endif
+
+#ifdef  USE_STREAMLOG
+
+#include "logstream.h"
+#include "logscope.h"
+#include "loglevels.h"
+
+
+#define  streamlog_level( MLEVEL ) ( streamlog::out.would_write< streamlog::MLEVEL >() )
+
+
+#define  streamlog_out( MLEVEL ) if(streamlog::out.write< streamlog::MLEVEL >() ) streamlog::out()  
+
+
+#define  streamlog_message( MLEVEL , CODE_BLOCK , OUT_MESSAGE)\
+   if( streamlog::out.write< streamlog::MLEVEL >() ) { \
+      CODE_BLOCK \
+    streamlog::out() << OUT_MESSAGE }
+
+//for use in templated classes with gcc 3.2 use these macros:
+#define  streamlog_out_T( MLEVEL ) if(streamlog::out.template write< streamlog::MLEVEL >() ) streamlog::out() 
+
+#define  streamlog_message_T( MLEVEL , CODE_BLOCK , OUT_MESSAGE)\
+   if( streamlog::out.template write< streamlog::MLEVEL >() ) { \
+      CODE_BLOCK \
+    streamlog::out() << OUT_MESSAGE }
+
+#else
+
+#define  streamlog_out( MLEVEL ) std::cout
+
+#define  streamlog_message( MLEVEL , CODE_BLOCK , OUT_MESSAGE)\
+   if( true ) { \
+      CODE_BLOCK \
+      std::out << OUT_MESSAGE }
+
+#endif
+
+
+#endif

--- a/src/KiTrack/Automaton.cc
+++ b/src/KiTrack/Automaton.cc
@@ -419,7 +419,7 @@ void Automaton::doAutomaton(){
 
 
 
-void Automaton::cleanBadStates(){
+void Automaton::cleanBadStates( int LayerOffset ){
 
 
 
@@ -436,7 +436,7 @@ void Automaton::cleanBadStates(){
 
          Segment* segment = *iSeg;
 
-         if( segment->getInnerState() == (int) layer ){ //the state is alright (equals the layer), this segment is good
+         if( segment->getInnerState() == (int) layer - LayerOffset ){ //the state is alright (equals the layer), this segment is good
 
             nKeptSegments++;
 
@@ -631,7 +631,7 @@ std::vector < std::vector< IHit* > > Automaton::getTracksOfSegment ( Segment* se
       for ( std::list<Segment*>::iterator iChild=children.begin(); iChild!= children.end(); iChild++){ //for all children
          
          
-         std::vector < std::vector< IHit* > > newTracks = getTracksOfSegment( *iChild , hits );
+         std::vector < std::vector< IHit* > > newTracks = getTracksOfSegment( *iChild , hits, minHits );
          
          for (unsigned int j=0; j < newTracks.size(); j++){//for all the tracks of the child
             

--- a/src/marlin/logstream.cc
+++ b/src/marlin/logstream.cc
@@ -1,0 +1,95 @@
+#include "marlin/logstream.h"
+
+#include "marlin/logbuffer.h"
+#include "marlin/prefix.h"
+
+namespace streamlog{
+  
+  logstream::logstream() : 
+    _ns( new nullstream ) , 
+    _os(0) , 
+    _level(0) ,
+    _active(false) , 
+    _lb(0),
+    _prefix( new streamlog::prefix) {
+    
+  } 
+
+  logstream::~logstream() {
+    
+    if( _ns ){ 
+        delete _ns ;
+        _ns = NULL ;
+    }
+    
+    if( _os ){ 
+      delete _os ;
+      _os = NULL ;
+    }
+    
+    if( _lb ){
+      delete _lb ;
+      _lb = NULL ;
+    }
+    
+    if( _prefix ){
+      delete _prefix ;
+      _prefix = NULL ; 
+    }
+  }
+  
+  void logstream::init( std::ostream& os , const std::string name ) {
+    
+    static bool first=true ;
+    
+    if( first && os ) {
+      
+      //      _name = name ;      
+      
+      // create a new log buffer and attach this to a wrapper to the given ostream  
+
+      _lb = new logbuffer( os.rdbuf() , this ) ;
+      
+      _os = new std::ostream( _lb ) ;
+      
+      //attach also the original stream to the logger...
+      //os.rdbuf( _lb ) ; // this needs some work 
+      // FIXME : this needs to go to the c'tor !!!!
+     
+      _prefix->_name = name ;
+
+      first = false ;
+    }
+    
+    else if( !os) {
+      std::cerr << "ERROR: logstream::init() invalid ostream given " << std::endl ;      
+    }
+  }
+
+  unsigned logstream::setLevel( const std::string& levelName ) {
+
+    unsigned l = _level ;
+    LevelMap::iterator it = _map.find( levelName ) ;
+    if( it != _map.end() ) {
+      _level = it->second ;
+    }
+    return l ;
+  } 
+
+
+  std::ostream& logstream::operator()() { 
+    
+    if( _active && _os ) {
+      
+      _active = false ;
+      
+      return *_os ;
+    }
+    else
+      return *_ns ;
+    
+  }
+
+  /** global instance of logstream */
+  logstream out ;
+}

--- a/src/marlin/prefix.cc
+++ b/src/marlin/prefix.cc
@@ -1,0 +1,10 @@
+#include "marlin/prefix.h"
+
+namespace streamlog{
+
+  prefix_base::prefix_base() : _name("UNKOWN") , _levelName("VERBOSE") {
+  }
+  
+  prefix_base::~prefix_base() {
+  }
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed case in which minTrack length was not respected - leading to tracks shorter than desired length
- Added option to skip one or more layers when cleaning bad states.
- added in an implementation of the streamlog to prevent output of all debug info to cout

ENDRELEASENOTES

@plexoos if/when you accept this pull request, please also update star-sw git tag in cmake targets to pull the newest version.